### PR TITLE
fix: uses documentStore instead of certificateStore

### DIFF
--- a/schema/2.0/example.json
+++ b/schema/2.0/example.json
@@ -18,13 +18,21 @@
       "did": "DID:SG-UEN:U18274928E",
       "url": "https://blockchainacademy.com",
       "email": "registrar@blockchainacademy.com",
-      "certificateStore": "0xd9580260be45c3c0c2fb259a82f219b513054012",
+      "documentStore": "0xd9580260be45c3c0c2fb259a82f219b513054012",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      },
       "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000"
     },
     {
       "name": "School of Crypto-economics",
       "url": "https://ceschool.sg",
-      "certificateStore": "0xA33ddAEE02369D18A21E29dD2E7A12d65eE671d2"
+      "documentStore": "0xA33ddAEE02369D18A21E29dD2E7A12d65eE671d2",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      }
     }
   ],
   "recipient": {

--- a/schema/2.0/schema.json
+++ b/schema/2.0/schema.json
@@ -164,7 +164,7 @@
             "additionalProperties": false
           }
         },
-        "required": ["name", "documentStore", "identityProof"],
+        "required": ["name", "documentStore"],
         "additionalProperties": true
       },
       "minItems": 1

--- a/schema/2.0/schema.json
+++ b/schema/2.0/schema.json
@@ -145,11 +145,26 @@
           "phone": {
             "type": "string"
           },
-          "certificateStore": {
+          "documentStore": {
             "type": "string"
+          },
+          "identityProof": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["DNS-TXT"]
+              },
+              "location": {
+                "type": "string",
+                "description": "Url of the website referencing to document store"
+              }
+            },
+            "required": ["type", "location"],
+            "additionalProperties": false
           }
         },
-        "required": ["name", "certificateStore"],
+        "required": ["name", "documentStore", "identityProof"],
         "additionalProperties": true
       },
       "minItems": 1

--- a/schema/2.0/schema.test.js
+++ b/schema/2.0/schema.test.js
@@ -442,6 +442,76 @@ describe("schema/v2.0", () => {
       const signing = () => issueDocument(data, schema);
       expect(signing).to.throw("Invalid document");
     });
+
+    it("should fail when identity type is missing", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).to.throw("Invalid document");
+    });
+
+    it("should fail when identity location is missing", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).to.throw("Invalid document");
+    });
+
+    it("should fail when identity type is not dns-txt", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "ABC",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).to.throw("Invalid document");
+    });
   });
 
   it("is valid with additional properties in issuer", () => {

--- a/schema/2.0/schema.test.js
+++ b/schema/2.0/schema.test.js
@@ -33,7 +33,11 @@ describe("schema/v2.0", () => {
       issuers: [
         {
           name: "Issuer Name",
-          certificateStore: "0x0000000000000000000000000000000000000000"
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {
@@ -67,7 +71,11 @@ describe("schema/v2.0", () => {
       issuers: [
         {
           name: "Issuer Name",
-          certificateStore: "0x0000000000000000000000000000000000000000"
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {
@@ -89,7 +97,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -131,7 +143,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -168,7 +184,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -209,7 +229,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -250,7 +274,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -291,7 +319,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -331,7 +363,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -371,7 +407,11 @@ describe("schema/v2.0", () => {
         issuers: [
           {
             name: "Issuer Name",
-            certificateStore: "0x0000000000000000000000000000000000000000"
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
           }
         ],
         recipient: {
@@ -412,8 +452,12 @@ describe("schema/v2.0", () => {
       issuers: [
         {
           name: "Issuer Name",
-          certificateStore: "0x0000000000000000000000000000000000000000",
-          additionalProp: true
+          documentStore: "0x0000000000000000000000000000000000000000",
+          additionalProp: true,
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {
@@ -434,7 +478,11 @@ describe("schema/v2.0", () => {
       issuers: [
         {
           name: "Issuer Name",
-          certificateStore: "0x0000000000000000000000000000000000000000"
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {
@@ -461,7 +509,11 @@ describe("schema/v2.0", () => {
           did: "DID:SG-UEN:U18274928E",
           url: "https://blockchainacademy.com",
           email: "registrar@blockchainacademy.com",
-          certificateStore: "0xd9580260be45c3c0c2fb259a82f219b513054012"
+          documentStore: "0xd9580260be45c3c0c2fb259a82f219b513054012",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {
@@ -503,7 +555,11 @@ describe("schema/v2.0", () => {
       issuers: [
         {
           name: "Issuer Name",
-          certificateStore: "0x0000000000000000000000000000000000000000"
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
         }
       ],
       recipient: {

--- a/test/fixtures/testCerts.js
+++ b/test/fixtures/testCerts.js
@@ -11,7 +11,11 @@ const testCerts = [
         did: "DID:SG-UEN:U18274928E",
         url: "https://blockchainacademy.com",
         email: "registrar@blockchainacademy.com",
-        certificateStore: "0xd9580260be45c3c0c2fb259a82f219b513054012",
+        documentStore: "0xd9580260be45c3c0c2fb259a82f219b513054012",
+        identityProof: {
+          type: "DNS-TXT",
+          location: "example.com"
+        },
         additionalProps: "issuerId"
       }
     ],
@@ -52,7 +56,11 @@ const testCerts = [
         did: "DID:SG-UEN:U18274928E",
         url: "https://blockchainacademy.com",
         email: "registrar@blockchainacademy.com",
-        certificateStore: "0xd9580260be45c3c0c2fb259a82f219b513054012"
+        documentStore: "0xd9580260be45c3c0c2fb259a82f219b513054012",
+        identityProof: {
+          type: "DNS-TXT",
+          location: "example.com"
+        }
       }
     ],
     recipient: {


### PR DESCRIPTION
Update v2 schema
- certificateStore becomes documentStore
- identityProof is added like for oa v2 and is OPTIONAL