### PR TITLE
feat: Add schema S3/CloudFront deploy, CLAUDE.md, and deploy docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 dist
+deploy

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -1,0 +1,64 @@
+name: Deploy schemas
+
+# Publishes the JSON Schemas, examples and W3C VC contexts to S3 (behind
+# CloudFront).
+#   - DEV:  auto-deploys on push to develop             (DEV_* credentials)
+#   - PROD: manual only — run this workflow from master (AWS_* credentials)
+# workflow_dispatch deploys the environment matching the branch it is run from
+# (master -> production, anything else -> development).
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "schema/**"
+      - "scripts/publishSchema.sh"
+      - ".github/workflows/deploy-schema.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-schema-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve target environment
+        id: target
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            echo "env=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "env=development" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Deploying to ${{ github.ref }} -> $(cat "$GITHUB_OUTPUT" | tail -1)"
+
+      - name: Build public/ schema tree
+        run: sh scripts/publishSchema.sh
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ github.ref == 'refs/heads/master' && secrets.AWS_ACCESS_KEY_ID || secrets.DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ github.ref == 'refs/heads/master' && secrets.AWS_SECRET_ACCESS_KEY || secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Sync to S3
+        env:
+          BUCKET: ${{ github.ref == 'refs/heads/master' && secrets.SCHEMA_S3_BUCKET || secrets.DEV_SCHEMA_S3_BUCKET }}
+        run: |
+          aws s3 sync public/ "s3://${BUCKET}/" \
+            --delete \
+            --cache-control "public, max-age=300"
+
+      - name: Invalidate CloudFront
+        env:
+          DISTRIBUTION_ID: ${{ github.ref == 'refs/heads/master' && secrets.SCHEMA_CLOUDFRONT_DISTRIBUTION_ID || secrets.DEV_SCHEMA_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${DISTRIBUTION_ID}" \
+            --paths "/*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+Guidance for working in this repo (for developers and for Claude Code).
+
+## What this repo is
+
+`@opencerts/open-certificate` supplies the **JSON Schemas** for OpenCerts documents,
+plus a small JS library to issue/validate them. It supports **two document formats**:
+
+| Format | Schema versions | Tooling |
+| --- | --- | --- |
+| **OpenAttestation** verifiable documents (original) | `transcripts/1.0`–`2.2`, `testimonials/1.0`, `certificate-of-awards/1.0` | `@tradetrust-tt/tradetrust` (the maintained OA engine in the TrustVC stack) |
+| **W3C Verifiable Credentials** (Data Model 2.0) | `transcripts/3.0`, `testimonials/2.0`, `certificate-of-awards/2.0` | `@trustvc/trustvc` |
+
+## Repo layout
+
+```
+schema/<type>/<version>/
+  schema.json      # JSON Schema (draft-07); its $id is the hosted URL
+  example.json     # sample document
+  context.json     # JSON-LD @context — W3C VC versions ONLY (required for signing)
+  changelog        # human notes for the version
+  schema.test.js   # tests for that version
+src/index.js       # the openCert.* library (issue/validate/verify/obfuscate)
+test/oa-compat.js  # Ajv shim used by the OpenAttestation transcript tests
+scripts/publishSchema.sh  # builds public/ for hosting
+deploy/            # S3/CloudFront deployment (CloudFront function + setup docs)
+```
+
+## Prerequisites & commands
+
+- **Node.js >= 22 is required** (enforced by `engines` + `engine-strict` in `.npmrc`; `.nvmrc` pins 22). Run `nvm use`.
+  - TrustVC pulls in ES-module-only crypto deps that only load cleanly on Node 22+.
+- `npm install` — also runs `prepare` (builds `dist/`), since this package is **not published to npm** and is consumed via git install.
+- `npm test` — Jest 29.
+- `npm run lint` / `npm run build`.
+
+## The library (`src/index.js`)
+
+Modern OpenAttestation removed custom-schema registration (`addSchema`), so the library is a **hybrid**:
+- **Ajv** validates documents against the custom OpenCerts schemas (`validateSchema`, and the pre-wrap check in `issueCertificate`).
+- **`@tradetrust-tt/tradetrust`** does the OA document ops: `wrapDocument`/`wrapDocuments`, `getData`, `verifySignature`, `obfuscateDocument`, `MerkleTree`.
+- `issueCertificate` seeds an empty `privacy` on the wrapped doc to preserve the legacy document shape.
+
+> We import OA functions from `@tradetrust-tt/tradetrust` (not `@trustvc/trustvc`) on purpose: TrustVC's own OA wrappers are async, drop the `schema` field, and return non-boolean verify results. `@tradetrust-tt/tradetrust` is the same engine TrustVC bundles, but exposes the classic sync API this library needs.
+
+## Testing
+
+- **W3C VC suites** (`*/2.0`, `transcripts/3.0`) use `@trustvc/trustvc` directly: JSON-Schema validation (Ajv) + raw-VC checks (`vc.isRawDocumentV2_0`) + end-to-end **sign → derive → verify**, tamper rejection, and selective disclosure.
+- **OpenAttestation transcript tests** use `test/oa-compat.js` — a small Ajv shim that replaces the deprecated `@govtechsg/open-attestation` (`issueDocument`/`addSchema`/`validateSchema`).
+- The `1.0` cert/testimonial tests resolve the OpenAttestation v2 schema from the locally-installed `@tradetrust-tt/tradetrust` (no network dependency on `schema.openattestation.com`).
+- Jest config (`jest.config.js`) has `transformIgnorePatterns`/`customExportConditions` + a root `babel.config.js` so TrustVC's ESM deps load under the CommonJS suites.
+
+## Adding a new schema version
+
+1. Create `schema/<type>/<version>/` with `schema.json`, `example.json`, `changelog`, `schema.test.js` (+ `context.json` for W3C VC).
+2. If it's a transcript version consumed by the library, register it in `src/index.js` `schemas`.
+3. Add it to `scripts/publishSchema.sh` (a `copy "<type>" "<version>"` line) so it gets hosted.
+4. `npm test` + `npm run lint`.
+
+## Hosting / deployment
+
+- `scripts/publishSchema.sh` builds `public/` from `schema/`: `schema.json` → `index.json`, plus `example.json` and `context.json`. (`public/` is gitignored build output.)
+- **`.github/workflows/deploy-schema.yml`** syncs `public/` to S3 (behind CloudFront) and invalidates:
+  - **dev**: auto on push to `develop` (`DEV_*` secrets).
+  - **prod**: manual only — run the workflow from `master` (`AWS_*` secrets).
+- **CloudFront Function** (`deploy/cloudfront-rewrite.js`) rewrites extension-less URLs (`/transcripts/3.0` → `/transcripts/3.0/index.json`). It replaces the old Netlify `_redirects` and must be set up **once per distribution** (see `deploy/README.md`). It is **not** managed by the workflow.
+- Repo needs these GitHub **secrets**: `SCHEMA_S3_BUCKET`, `SCHEMA_CLOUDFRONT_DISTRIBUTION_ID`, `DEV_SCHEMA_S3_BUCKET`, `DEV_SCHEMA_CLOUDFRONT_DISTRIBUTION_ID` (in addition to the `AWS_*` / `DEV_AWS_*` credentials).
+
+## Branches
+
+- `master` → production; `develop` → dev/integration. CI (`ci.yml`) runs lint/test/build on Node 22.
+
+## Gotchas (things that have tripped people up)
+
+- **`"@version": 1.1` in `context.json` is the JSON-LD spec version, NOT the schema version.** It must stay `1.1` (there is no JSON-LD 2.0); it enables the 1.1 features the contexts use (`@protected`, scoped `@context`, `@type: "@id"`, `@container: "@set"`, `@type: "@json"`). The schema version lives in the `$id`/folder; the VC Data Model version is the first `@context` entry (`…/credentials/v2`).
+- **`ecdsa-sd-2023` (default) is selective-disclosure**, so a signed credential must be **derived** before it verifies. `deriveCredential(signed, ["/credentialSubject/name"], …)` then `verifyCredential`. `verifyDocument` (fragments) auto-derives internally — **but only if the `@context` is resolvable by its loader** (i.e. hosted, or served locally in tests), because its internal derive uses the default document loader, not one you pass in.
+- **W3C VC `context.json` must be hosted** at the URL in the credential's `@context` for third parties to sign/verify. In tests we map it locally via `getDocumentLoader({ [url]: context })`.
+- **`did:web` needs its DID document hosted** (`https://<domain>/.well-known/did.json`); `did:key` is self-resolving (used in offline tests).
+- **`issuer` is `{ id, name }`** (a DID + name), not the old OpenAttestation `issuers[]` array.
+- **`additionalData` is freeform** (`@type: "@json"` in the context) — arbitrary content (`images`, `npfa`, …) is valid without defining each field.
+- The certificate/testimonial signatory image field is **`signatureImage`**, not `signature` (a JSON-LD term can't redefine itself inside its own scope, which breaks canonicalization).
+- **Not published to npm.** Install from git (`npm install github:OpenCerts/open-certificate`); `prepare` builds it. Require it as `@opencerts/open-certificate`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,84 @@
+# Schema hosting (S3 + CloudFront)
+
+The JSON Schemas, examples and W3C VC contexts under [`../schema`](../schema) are
+published to S3 (behind CloudFront) by the
+[`Deploy schemas`](../.github/workflows/deploy-schema.yml) GitHub Actions workflow.
+
+- Push to **`develop`** → **development** bucket/distribution (uses `DEV_*` creds)
+- Push to **`master`** → **production** bucket/distribution (uses `AWS_*` creds)
+- Manual **workflow_dispatch** deploys the environment matching the branch it runs on.
+
+The workflow runs `scripts/publishSchema.sh` to build the `public/` tree, then
+`aws s3 sync public/ …` and a CloudFront invalidation.
+
+## One-time setup
+
+### 1. GitHub secrets (already present)
+
+| Secret | Used for |
+| --- | --- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | production deploy |
+| `DEV_AWS_ACCESS_KEY_ID` / `DEV_AWS_SECRET_ACCESS_KEY` | development deploy |
+| `AWS_REGION` | region for both (add `DEV_AWS_REGION` + wire it in if dev differs) |
+
+### 2. GitHub repository secrets (add these)
+
+Settings → Secrets and variables → Actions → **Secrets**:
+
+| Secret | Example |
+| --- | --- |
+| `SCHEMA_S3_BUCKET` | `prod-opencerts-schema` |
+| `SCHEMA_CLOUDFRONT_DISTRIBUTION_ID` | `E1XXXXXXXXXXXX` |
+| `DEV_SCHEMA_S3_BUCKET` | `dev-opencerts-schema` |
+| `DEV_SCHEMA_CLOUDFRONT_DISTRIBUTION_ID` | `E2XXXXXXXXXXXX` |
+
+(Bucket names / distribution IDs aren't sensitive, so GitHub *Variables* would
+also work — but the workflow reads `secrets.*`, so keep them in **Secrets**.)
+
+### 3. IAM permissions for each deploy user
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::<bucket>"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::<bucket>/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["cloudfront:CreateInvalidation"],
+      "Resource": "arn:aws:cloudfront::<account-id>:distribution/<distribution-id>"
+    }
+  ]
+}
+```
+
+### 4. CloudFront Function (URL rewrite)
+
+To serve the schema at its extension-less `$id` URL (e.g. `https://schema.opencerts.io/transcripts/3.0`),
+create a CloudFront **Function** from [`cloudfront-rewrite.js`](./cloudfront-rewrite.js)
+and attach it to the distribution's **default cache behavior** as a
+**viewer-request** function (do this on both the dev and prod distributions).
+
+Console: CloudFront → Functions → Create function → paste the file → Publish →
+Add association (distribution, default behavior, Viewer request).
+
+Or via CLI:
+
+```sh
+aws cloudfront create-function \
+  --name opencerts-schema-rewrite \
+  --function-config Comment="append index.json",Runtime=cloudfront-js-2.0 \
+  --function-code fileb://deploy/cloudfront-rewrite.js
+# then publish-function and associate it with the distribution behavior
+```
+
+`example.json` and `context.json` are real files, so they are served directly
+and are unaffected by the rewrite.

--- a/deploy/cloudfront-rewrite.js
+++ b/deploy/cloudfront-rewrite.js
@@ -1,0 +1,28 @@
+// CloudFront Function (runtime: cloudfront-js-2.0), event type: viewer-request.
+//
+// Serves the schema at extension-less URLs by rewriting them to the index.json
+// object that publishSchema.sh uploads.
+//
+//   /transcripts/3.0               -> /transcripts/3.0/index.json   (schema)
+//   /transcripts/3.0/              -> /transcripts/3.0/index.json
+//   /transcripts/3.0/example.json  (unchanged — already a .json file)
+//   /transcripts/3.0/context.json  (unchanged — already a .json file)
+//
+// All hosted objects are .json (index.json / example.json / context.json), so
+// the rule is: if the request doesn't already end in ".json", it's a schema
+// version path (e.g. /certificate-of-awards/1.0 — note the dot in the version)
+// and should serve that folder's index.json.
+//
+// Attach to the distribution's default cache behavior as a viewer-request function.
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.endsWith("/")) {
+    request.uri = uri + "index.json";
+  } else if (!uri.endsWith(".json")) {
+    request.uri = uri + "/index.json";
+  }
+
+  return request;
+}

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,0 @@
-# /transcript/2.0/ /transcript/2.0/index.json 200
-/* /:splat/index.json 200

--- a/scripts/publishSchema.sh
+++ b/scripts/publishSchema.sh
@@ -3,15 +3,29 @@
 copy() {
     folder=$1
     version=$2
+    dir="public/${folder}/${version}"
+    mkdir -p "${dir}"
+
+    # schema.json is served as index.json (a CloudFront function rewrites
+    # extension-less paths, e.g. /transcripts/3.0, to /transcripts/3.0/index.json)
     from="schema/${folder}/${version}/schema.json"
-    to="public/${folder}/${version}/index.json"
+    to="${dir}/index.json"
     echo "Moving ${from} to ${to}"
-    mkdir -p "public/${folder}/${version}/"
-    cp ${from} ${to}
-    # copy example
+    cp "${from}" "${to}"
+
+    # example.json (all versions)
     from="schema/${folder}/${version}/example.json"
-    to="public/${folder}/${version}/example.json"
-    cp ${from} ${to}
+    if [ -f "${from}" ]; then
+        cp "${from}" "${dir}/example.json"
+    fi
+
+    # context.json (W3C Verifiable Credential versions only) — must be hosted so
+    # the credential's @context URL resolves for signing/verification.
+    from="schema/${folder}/${version}/context.json"
+    if [ -f "${from}" ]; then
+        echo "Moving ${from} to ${dir}/context.json"
+        cp "${from}" "${dir}/context.json"
+    fi
 }
 
 # Copy schemas to public folder
@@ -25,7 +39,10 @@ copy "transcripts" "1.5"
 copy "transcripts" "2.0"
 copy "transcripts" "2.1"
 copy "transcripts" "2.2"
+copy "transcripts" "3.0"
 # copy testimonials
 copy "testimonials" "1.0"
+copy "testimonials" "2.0"
 # copy certificate of awards
 copy "certificate-of-awards" "1.0"
+copy "certificate-of-awards" "2.0"


### PR DESCRIPTION
- deploy-schema.yml: publish schema/ (schemas, examples, W3C VC contexts) to S3 behind CloudFront. DEV auto-deploys on push to develop (DEV_* creds); PROD is manual only via workflow_dispatch from master (AWS_* creds). Bucket and distribution id come from repository secrets. Runs publishSchema.sh, aws s3 sync, then a CloudFront invalidation.
- publishSchema.sh: include the W3C VC versions (certificate-of-awards/2.0, testimonials/2.0, transcripts/3.0) and copy each context.json.
- deploy/cloudfront-rewrite.js + deploy/README.md: CloudFront viewer-request function that rewrites extension-less schema paths (e.g. /transcripts/3.0, including the dot in the version) to /index.json — replaces the Netlify _redirects — plus one-time setup docs.
- Remove public/_redirects (Netlify-only; superseded by the CloudFront function).
- CLAUDE.md: onboarding/context doc — architecture, dev workflow, testing, adding a schema version, hosting, and known gotchas.
- .eslintignore: exclude deploy/ (CloudFront runtime code, not library source).